### PR TITLE
Handle brand UPP Identifiers & Use new Neo Utils 

### DIFF
--- a/content/content_service.go
+++ b/content/content_service.go
@@ -148,8 +148,8 @@ func (pcd service) Write(thing interface{}) error {
 	}
 
 	statement := `MERGE (n:Thing {uuid: {uuid}})
-										set n={allprops}
-										set n :Content`
+		      set n={allprops}
+		      set n :Content`
 
 	writeContentQuery := &neoism.CypherQuery{
 		Statement: statement,
@@ -164,9 +164,12 @@ func (pcd service) Write(thing interface{}) error {
 }
 
 func addBrandsQuery(brandUuid string, contentUuid string) *neoism.CypherQuery {
-	statement := `MERGE (b:Thing{uuid:{brandUuid}})
-						MERGE (c:Thing{uuid:{contentUuid}})
-						MERGE (c)-[rel:IS_CLASSIFIED_BY{platformVersion:{platformVersion}, lifecycle: "content"}]->(b)`
+	statement := `	MERGE (brandIdentifier:Identifier:UPPIdentifier{value:{brandUuid}})
+			MERGE(brand:Thing{uuid:{brandUuid}})
+			MERGE(brandIdentifier)-[:IDENTIFIES]->(brand)
+			ON CREATE SET brandIdentifier.uuid = {brandUuid}
+			MERGE(content:Thing{uuid:{contentUuid}})
+			MERGE(content)-[rel:IS_CLASSIFIED_BY{platformVersion:{platformVersion}, lifecycle: "content"}]->(brand)`
 
 	query := &neoism.CypherQuery{
 		Statement: statement,

--- a/content/content_service.go
+++ b/content/content_service.go
@@ -16,7 +16,7 @@ var uuidExtractRegex = regexp.MustCompile(".*/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{
 
 // CypherDriver - CypherDriver
 type service struct {
-	cypherRunner neoutils.NeoConnection
+	conn neoutils.NeoConnection
 }
 
 //NewCypherDriver instantiate driver
@@ -27,7 +27,7 @@ func NewCypherContentService(cypherRunner neoutils.NeoConnection) service {
 //Initialise initialisation of the indexes
 func (cd service) Initialise() error {
 
-	err := cd.cypherRunner.EnsureIndexes(map[string]string{
+	err := cd.conn.EnsureIndexes(map[string]string{
 		"Identifier": "value",
 	})
 
@@ -35,13 +35,13 @@ func (cd service) Initialise() error {
 		return err
 	}
 
-	return cd.cypherRunner.EnsureConstraints(map[string]string{
+	return cd.conn.EnsureConstraints(map[string]string{
 		"Content":     	 "uuid",
 		"Brand":         "uuid"})
 }
 // Check - Feeds into the Healthcheck and checks whether we can connect to Neo and that the datastore isn't empty
 func (pcd service) Check() error {
-	return neoutils.Check(pcd.cypherRunner)
+	return neoutils.Check(pcd.conn)
 }
 
 // Read - reads a content given a UUID
@@ -63,7 +63,7 @@ func (pcd service) Read(uuid string) (interface{}, bool, error) {
 		Result: &results,
 	}
 
-	err := pcd.cypherRunner.CypherBatch([]*neoism.CypherQuery{query})
+	err := pcd.conn.CypherBatch([]*neoism.CypherQuery{query})
 
 	if err != nil {
 		return content{}, false, err
@@ -160,7 +160,7 @@ func (pcd service) Write(thing interface{}) error {
 	}
 	queries = append(queries, writeContentQuery)
 
-	return pcd.cypherRunner.CypherBatch(queries)
+	return pcd.conn.CypherBatch(queries)
 }
 
 func addBrandsQuery(brandUuid string, contentUuid string) *neoism.CypherQuery {
@@ -221,7 +221,7 @@ func (pcd service) Delete(uuid string) (bool, error) {
 		},
 	}
 
-	err := pcd.cypherRunner.CypherBatch([]*neoism.CypherQuery{clearNode, removeNodeIfUnused})
+	err := pcd.conn.CypherBatch([]*neoism.CypherQuery{clearNode, removeNodeIfUnused})
 
 	s1, err := clearNode.Stats()
 	if err != nil {
@@ -256,7 +256,7 @@ func (pcd service) Count() (int, error) {
 		Result:    &results,
 	}
 
-	err := pcd.cypherRunner.CypherBatch([]*neoism.CypherQuery{query})
+	err := pcd.conn.CypherBatch([]*neoism.CypherQuery{query})
 
 	if err != nil {
 		return 0, err

--- a/content/content_service_test.go
+++ b/content/content_service_test.go
@@ -247,8 +247,8 @@ func TestWriteCalculateEpocCorrectly(t *testing.T) {
 	defer cleanDB(db, t, assert)
 
 	uuid := "12345"
-	contentRecieved := content{UUID: uuid, Title: "TestContent", PublishedDate: "1970-01-01T01:00:00.000Z", Body: "Some Test text"}
-	contentDriver.Write(contentRecieved)
+	contentReceived := content{UUID: uuid, Title: "TestContent", PublishedDate: "1970-01-01T01:00:00.000Z", Body: "Some Test text"}
+	contentDriver.Write(contentReceived)
 
 	result := []struct {
 		PublishedDateEpoc int `json:"t.publishedDateEpoch"`
@@ -377,7 +377,9 @@ func writeClassifedByRelationship(db neoutils.NeoConnection, contentId string, c
 }
 
 func checkClassifedByRelationship(db neoutils.NeoConnection, conceptId string, lifecycle string, t *testing.T, assert *assert.Assertions) int {
-	countQuery := `Match (t:Thing{uuid:{conceptId}})-[r:IS_CLASSIFIED_BY {platformVersion:'v1', lifecycle: {lifecycle}}]-(x) return count(r) as c`
+	countQuery := `	MATCH (t:Thing{uuid:{conceptId}})-[r:IS_CLASSIFIED_BY {platformVersion:'v1', lifecycle: {lifecycle}}]-(x)
+			MATCH (t)<-[:IDENTIFIES]-(s:Identifier:UPPIdentifier)
+			RETURN count(r) as c`
 
 	results := []struct {
 		Count int `json:"c"`

--- a/content/content_service_test.go
+++ b/content/content_service_test.go
@@ -324,7 +324,7 @@ func getDatabaseConnection(assert *assert.Assertions) *neoism.Database {
 	return db
 }
 
-func cleanDB(db *neoism.Database, t *testing.T, assert *assert.Assertions) {
+func cleanDB(db neoutils.CypherRunner, t *testing.T, assert *assert.Assertions) {
 	qs := []*neoism.CypherQuery{
 		{
 			Statement: fmt.Sprintf("MATCH (mc:Thing {uuid: '%v'}) DETACH DELETE mc", minimalContentUuid),
@@ -347,7 +347,7 @@ func writeClassifedByRelationship(db *neoism.Database, contentId string, concept
                 MERGE (content:Thing{uuid:{contentId}})
                 MERGE (upp:Identifier:UPPIdentifier{value:{conceptId}})
                 MERGE (upp)-[:IDENTIFIES]->(concept:Thing) ON CREATE SET concept.uuid = {conceptId}
-                MERGE (content)-[pred:IS_CLASSIFIED_BY {platformVersion:'v1'}]->(concept)              
+                MERGE (content)-[pred:IS_CLASSIFIED_BY {platformVersion:'v1'}]->(concept)
           `
 		qs = []*neoism.CypherQuery{
 			{
@@ -393,7 +393,7 @@ func checkClassifedByRelationship(db *neoism.Database, conceptId string, lifecyc
 	return results[0].Count
 }
 
-func checkDbClean(db *neoism.Database, t *testing.T) {
+func checkDbClean(db neoutils.CypherRunner, t *testing.T) {
 	assert := assert.New(t)
 
 	result := []struct {
@@ -409,7 +409,7 @@ func checkDbClean(db *neoism.Database, t *testing.T) {
 		},
 		Result: &result,
 	}
-	err := db.Cypher(&checkGraph)
+	err := db.CypherBatch([]*neoism.CypherQuery{&checkGraph})
 	assert.NoError(err)
 	assert.Empty(result)
 }

--- a/content/content_service_test.go
+++ b/content/content_service_test.go
@@ -261,7 +261,7 @@ func TestWriteCalculateEpocCorrectly(t *testing.T) {
 		Result: &result,
 	}
 
-	err := contentDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{getEpocQuery})
+	err := contentDriver.conn.CypherBatch([]*neoism.CypherQuery{getEpocQuery})
 	assert.NoError(err)
 	assert.Equal(3600, result[0].PublishedDateEpoc, "Epoc of 1970-01-01T01:00:00.000Z should be 3600")
 }
@@ -288,7 +288,7 @@ func TestWritePrefLabelIsAlsoWrittenAndIsEqualToTitle(t *testing.T) {
 		Result: &result,
 	}
 
-	err := contentDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{getPrefLabelQuery})
+	err := contentDriver.conn.CypherBatch([]*neoism.CypherQuery{getPrefLabelQuery})
 	assert.NoError(err)
 	assert.Equal("TestContent", result[0].PrefLabel, "PrefLabel should be 'TestContent")
 }

--- a/content/content_service_test.go
+++ b/content/content_service_test.go
@@ -274,8 +274,8 @@ func TestWritePrefLabelIsAlsoWrittenAndIsEqualToTitle(t *testing.T) {
 	defer cleanDB(db, t, assert)
 
 	uuid := "12345"
-	contentRecieved := content{UUID: uuid, Title: "TestContent", PublishedDate: "1970-01-01T01:00:00.000Z", Body: "Some Test text"}
-	contentDriver.Write(contentRecieved)
+	contentReceived := content{UUID: uuid, Title: "TestContent", PublishedDate: "1970-01-01T01:00:00.000Z", Body: "Some Test text"}
+	contentDriver.Write(contentReceived)
 
 	result := []struct {
 		PrefLabel string `json:"t.prefLabel"`


### PR DESCRIPTION
This does two things:

1. When content comes in with an unknown brand it doesn't just add a thing node but a thing node with an UPPIdentifier

2. This updates to use the new Connect() based neoutils API.

Note that because our tests in other projects rely on our services API in here, merging this will mean that other projects tests may fail until they are updated.