### PR TITLE
Supporting videos from Next Video Editor

### DIFF
--- a/content/model.go
+++ b/content/model.go
@@ -1,12 +1,11 @@
 package content
 
-
 type content struct {
-	UUID          string  `json:"uuid,omitempty"`
-	Title         string  `json:"title,omitempty"`
-	PublishedDate string  `json:"publishedDate,omitempty"`
-	Body          string  `json:"body,omitempty"`
-	Type          string  `json:"type,omitempty"`
-	StoryPackage  string  `json:"storyPackage,omitempty"`
-	ContentPackage  string  `json:"contentPackage,omitempty"`
+	UUID           string `json:"uuid,omitempty"`
+	Title          string `json:"title,omitempty"`
+	PublishedDate  string `json:"publishedDate,omitempty"`
+	Body           string `json:"body,omitempty"`
+	Type           string `json:"type,omitempty"`
+	StoryPackage   string `json:"storyPackage,omitempty"`
+	ContentPackage string `json:"contentPackage,omitempty"`
 }


### PR DESCRIPTION
* Supporting videos from Next Video Editor, having no body
* Fixing some linter issues 
* Formatting with `go fmt`

**Note**: Videos would have `MediaResource` type for now. In order to exclude Images, which also have `MediaResource` type, there will be a separate PR filtering them out from the ingester side.

Also see https://sites.google.com/a/ft.com/universal-publishing/documentation/story-specs/3-mar-2017-next-video-platform-work for architecture diagram and other useful information