### PR TITLE
Write content types

### DIFF
--- a/content/content_service.go
+++ b/content/content_service.go
@@ -22,6 +22,7 @@ var contentTypesWithNoBody = map[string]bool{
 	"ContentPackage": true,
 	LiveBlogPackage:  true,
 	LiveBlogPost:     true,
+	"LiveEvent":      true,
 }
 
 type Service struct {

--- a/content/content_service_test.go
+++ b/content/content_service_test.go
@@ -97,6 +97,14 @@ var genericContentPackage = content{
 	Type:           "ContentPackage",
 }
 
+var liveBlogPackage = content{
+	UUID:           contentUUID,
+	Title:          "Content Title",
+	PublishedDate:  "1970-01-01T01:00:00.000Z",
+	ContentPackage: genericContentPackageUUID,
+	Type:           "LiveBlogPackage",
+}
+
 var shorterContent = content{
 	UUID: contentUUID,
 	Body: "With No Publish Date and No Title",
@@ -107,6 +115,46 @@ var updatedContent = content{
 	Title:         "New Title",
 	PublishedDate: "1999-12-12T01:00:00.000Z",
 	Body:          "Doesn't matter",
+}
+
+func TestGetContentLabels(t *testing.T) {
+	tests := map[string]struct {
+		Content  content
+		Expected string
+	}{
+		"No body content": {
+			Content:  contentWithoutABody,
+			Expected: ":Content",
+		},
+		"Placeholder": {
+			Content:  contentPlaceholder,
+			Expected: ":Content",
+		},
+		"Live blog": {
+			Content:  liveBlog,
+			Expected: ":Content:Article",
+		},
+		"Content Package": {
+			Content:  standardContentPackage,
+			Expected: ":Content:ContentPackage",
+		},
+		"generic Content Package": {
+			Content:  genericContentPackage,
+			Expected: ":Content:ContentPackage",
+		},
+		"live blog package": {
+			Content:  liveBlogPackage,
+			Expected: ":Content:ContentPackage:LiveBlogPackage",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual := getContentLabels(test.Content)
+			if actual != test.Expected {
+				t.Errorf("expected: '%s', got '%s'", test.Expected, actual)
+			}
+		})
+	}
 }
 
 func TestDeleteWithNoRelsIsDeleted(t *testing.T) {

--- a/content/content_service_test.go
+++ b/content/content_service_test.go
@@ -29,6 +29,7 @@ const (
 	genericContentPackageUUID    = "27cfe7eb-549d-4d51-9cfd-98ea887a571c"
 	graphicUUID                  = "087b42c2-ac7f-40b9-b112-98b3a7f9cd72"
 	audioContentUUID             = "128cfcf4-c394-4e71-8c65-198a675acf53"
+	liveEventUUID                = "23531906-9f98-45c7-a9db-d05bdb72eeaf"
 )
 
 var contentWithoutABody = content{
@@ -105,6 +106,11 @@ var liveBlogPackage = content{
 	Type:           "LiveBlogPackage",
 }
 
+var liveEventContent = content{
+	UUID: liveEventUUID,
+	Type: "LiveEvent",
+}
+
 var shorterContent = content{
 	UUID: contentUUID,
 	Body: "With No Publish Date and No Title",
@@ -145,6 +151,10 @@ func TestGetContentLabels(t *testing.T) {
 		"live blog package": {
 			Content:  liveBlogPackage,
 			Expected: ":Content:ContentPackage:LiveBlogPackage",
+		},
+		"live event": {
+			Content:  liveEventContent,
+			Expected: ":Content:LiveEvent",
 		},
 	}
 	for name, test := range tests {
@@ -547,6 +557,10 @@ func TestContentWontBeWrittenIfNoBodyWithInvalidType(t *testing.T) {
 	assert.Equal(content{}, storedContent, "No content should be written when the content has no body")
 }
 
+func TestLiveEventWillBeWritten(t *testing.T) {
+	testContentWillBeWritten(t, liveEventContent)
+}
+
 func TestLiveBlogsWillBeWrittenDespiteNoBody(t *testing.T) {
 	testContentWillBeWritten(t, liveBlog)
 }
@@ -618,6 +632,7 @@ func cleanDB(d *cmneo4j.Driver, assert *assert.Assertions) {
 		genericContentPackageUUID,
 		graphicUUID,
 		audioContentUUID,
+		liveEventUUID,
 	}
 
 	qs := []*cmneo4j.Query{}


### PR DESCRIPTION
# Description

## What

Add content type to the Content node labels in Neo4j. All Content types are under `Content` label.

## Why

https://financialtimes.atlassian.net/browse/UPPSF-2837

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
