### PR TITLE
Remove the dependency on `neo-model-utils-go`.

### DIFF
--- a/content/content_service_test.go
+++ b/content/content_service_test.go
@@ -5,12 +5,14 @@ package content
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"testing"
 
 	cmneo4j "github.com/Financial-Times/cm-neo4j-driver"
 	"github.com/Financial-Times/go-logger/v2"
-	"github.com/Financial-Times/neo-model-utils-go/mapper"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -122,6 +124,8 @@ var updatedContent = content{
 	PublishedDate: "1999-12-12T01:00:00.000Z",
 	Body:          "Doesn't matter",
 }
+
+var sortStringSlicesDesc = cmpopts.SortSlices(func(a, b string) bool { return a < b })
 
 func TestGetContentLabels(t *testing.T) {
 	tests := map[string]struct {
@@ -442,13 +446,10 @@ func TestWriteNodeLabelsAreWrittenForContent(t *testing.T) {
 	err = d.Write(getNodeLabelsQuery...)
 	assert.NoError(err)
 
-	nodeLabels, err := mapper.SortTypes(result[0].NodeLabels)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	assert.Len(nodeLabels, 2, "There should be 2 node labels: Thing, Content")
-	assert.Equal("Thing", nodeLabels[0], "Thing should be the parent label")
-	assert.Equal("Content", nodeLabels[1], "Content should be the child label")
+	want := []string{"Thing", "Content"}
+	eq := cmp.Equal(result[0].NodeLabels, want, sortStringSlicesDesc)
+	diff := cmp.Diff(result[0].NodeLabels, want, sortStringSlicesDesc)
+	assert.True(eq, fmt.Sprintf("- got, + want: %s", diff))
 }
 
 func TestWriteNodeLabelsAreWrittenForContentPackage(t *testing.T) {
@@ -477,14 +478,12 @@ func TestWriteNodeLabelsAreWrittenForContentPackage(t *testing.T) {
 
 	err = d.Write(getNodeLabelsQuery)
 	assert.NoError(err)
-	nodeLabels, err := mapper.SortTypes(result[0].NodeLabels)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	assert.Len(nodeLabels, 3, "There should be 3 node labels: Thing, Content, ContentPackage")
-	assert.Equal("Thing", nodeLabels[0], "Thing should be the grandparent label")
-	assert.Equal("Content", nodeLabels[1], "Content should be the parent label")
-	assert.Equal("ContentPackage", nodeLabels[2], "ContentPackage should be the child label")
+
+	want := []string{"Thing", "Content", "ContentPackage"}
+	eq := cmp.Equal(result[0].NodeLabels, want, sortStringSlicesDesc)
+	diff := cmp.Diff(result[0].NodeLabels, want, sortStringSlicesDesc)
+
+	assert.True(eq, fmt.Sprintf("- got, + want: %s", diff))
 }
 
 func TestWriteNodeLabelsAreWrittenForGenericContentPackage(t *testing.T) {
@@ -512,14 +511,12 @@ func TestWriteNodeLabelsAreWrittenForGenericContentPackage(t *testing.T) {
 
 	err = d.Write(getNodeLabelsQuery)
 	assert.NoError(err)
-	nodeLabels, err := mapper.SortTypes(result[0].NodeLabels)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	assert.Len(nodeLabels, 3, "There should be 3 node labels: Thing, Content, ContentPackage")
-	assert.Equal("Thing", nodeLabels[0], "Thing should be the grandparent label")
-	assert.Equal("Content", nodeLabels[1], "Content should be the parent label")
-	assert.Equal("ContentPackage", nodeLabels[2], "ContentPackage should be the child label")
+
+	want := []string{"Thing", "Content", "ContentPackage"}
+	eq := cmp.Equal(result[0].NodeLabels, want, sortStringSlicesDesc)
+	diff := cmp.Diff(result[0].NodeLabels, want, sortStringSlicesDesc)
+
+	assert.True(eq, fmt.Sprintf("- got, + want: %s", diff))
 }
 
 func TestContentWontBeWrittenIfNoBody(t *testing.T) {

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - neo4j
   neo4j:
-    image: neo4j:4.3-enterprise
+    image: neo4j:4.4-enterprise
     environment:
       NEO4J_AUTH: none
       NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Financial-Times/cm-neo4j-driver v1.1.0
 	github.com/Financial-Times/go-fthealth v0.0.0-20171204124831-1b007e2b37b7
 	github.com/Financial-Times/go-logger/v2 v2.0.1
-	github.com/Financial-Times/neo-model-utils-go v1.0.0
+	github.com/google/go-cmp v0.5.9
 	github.com/jawher/mow.cli v0.0.0-20170430135212-8327d12beb75
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,6 @@ github.com/Financial-Times/go-logger/v2 v2.0.1 h1:iekEfSsUtlkg+YkXTZo+/fIN2VbZ2/
 github.com/Financial-Times/go-logger/v2 v2.0.1/go.mod h1:Jpky5JYSX7xjGUClfA9hEMDmn40tUbfQQITjVIFGQiM=
 github.com/Financial-Times/http-handlers-go v0.0.0-20170809121007-229ac16f1d9e h1:/Y2wrSfkueFmdOIyQSABebfEe5P+yFyxBnmtnx1C0HM=
 github.com/Financial-Times/http-handlers-go v0.0.0-20170809121007-229ac16f1d9e/go.mod h1:sAkXv1oPYgNTYBYsYs83HwpYp7R50mvgBGGcsOlJtOw=
-github.com/Financial-Times/neo-model-utils-go v1.0.0 h1:0iTxDtXKkJ9vYQDE73KM/+ghtFLdq0U6bQPdiwaSEaQ=
-github.com/Financial-Times/neo-model-utils-go v1.0.0/go.mod h1:D5ny/A+002uCPCZbtP/E+qpY3//gYJzHw6sqqBUm2Lc=
 github.com/Financial-Times/service-status-go v0.0.0-20160323111542-3f5199736a3d h1:USNBTIof6vWGM49SYrxvC5Y8NqyDL3YuuYmID81ORZQ=
 github.com/Financial-Times/service-status-go v0.0.0-20160323111542-3f5199736a3d/go.mod h1:7zULC9rrq6KxFkpB3Y5zNVaEwrf1g2m3dvXJBPDXyvM=
 github.com/Financial-Times/transactionid-utils-go v0.2.0/go.mod h1:tPAcAFs/dR6Q7hBDGNyUyixHRvg/n9NW/JTq8C58oZ0=
@@ -44,8 +42,9 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.4.1-0.20170830053917-a659b61323b0 h1:WufQb+4501Pn15bGwgA1eE6QREDVyecaTILO3GJv/UQ=
@@ -84,7 +83,6 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v0.0.0-20170809224252-890a5c3458b4/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
# Description

The package will be archived soon. Its replacement - `cm-graph-ontology` does not have support for content nodes yet. As a result `google/cmp` is used in the tests.

## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-4238)


## Scope and particulars of this PR (Please tick all that apply)

- [x] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
