### PR TITLE
Integrate Open Policy Engine.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,20 +3,27 @@ version: 2.1
 orbs:
   ft-golang-ci: financial-times/golang-ci@1
 
+executors:
+  default-with-neo4j-and-opa:
+    docker:
+      - image: golang:1
+        environment:
+          GOPATH: /go
+          NEO4J_TEST_URL: "bolt://localhost:7687"
+          POLICY_AGENT_TEST_URL: "http://localhost:8181"
+      - image: neo4j:4.3.10-enterprise
+        environment:
+          NEO4J_AUTH: none
+          NEO4J_HEAP_MEMORY: 256
+          NEO4J_CACHE_MEMORY: 256M
+          NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"
+      - image: openpolicyagent/opa:0.57.0
+        command: [ "run", "--server", "--addr=0.0.0.0:8181", "--log-format=json-pretty", "--set=decision_logs.console=true" ]
+
 jobs:
   dredd:
+    executor: default-with-neo4j-and-opa
     working_directory: /go/src/github.com/Financial-Times/content-rw-neo4j
-    docker:
-    - image: golang:1
-      environment:
-        GOPATH: /go
-        NEO4J_TEST_URL: "bolt://neo4j:7687"
-    - image: neo4j:4.3.10-enterprise
-      environment:
-        NEO4J_AUTH: none
-        NEO4J_HEAP_MEMORY: 256
-        NEO4J_CACHE_MEMORY: 256M
-        NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"
     steps:
     - checkout
     - run:
@@ -36,6 +43,12 @@ jobs:
             npm install -g --unsafe-perm --loglevel warn --user 0 --no-progress dredd@8.0.0
             rm -rf /var/lib/apt/lists/*
     - run:
+        name: Add a dummy OPA policy.
+        command: |
+          curl --location --request PUT 'localhost:8181/v1/policies/c1d20fbc-e9bc-44fb-8b88-0e01d6b13225' \
+          --header 'Content-Type: text/plain' \
+          --data 'package content_rw_neo4j.special_content default is_special_content := false'
+    - run:
         name: Dredd API Testing
         command: dredd
 
@@ -47,7 +60,7 @@ workflows:
       - ft-golang-ci/build-and-test:
           name: build-and-test-project
           executor-name:
-            name: ft-golang-ci/default-with-neo4j
+            name: default-with-neo4j-and-opa
           context: cm-team-github
       - ft-golang-ci/docker-build:
           name: build-docker-image

--- a/content/model.go
+++ b/content/model.go
@@ -8,4 +8,5 @@ type content struct {
 	Type           string `json:"type,omitempty"`
 	StoryPackage   string `json:"storyPackage,omitempty"`
 	ContentPackage string `json:"contentPackage,omitempty"`
+	EditorialDesk  string `json:"editorialDesk,omitempty"`
 }

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -11,9 +11,11 @@ services:
     environment:
       - NEO4J_TEST_URL=bolt://neo4j:7687
       - CGO_ENABLED=1
+      - POLICY_AGENT_TEST_URL=http://opa:8181
     command: ["go", "test", "-mod=readonly", "-v", "-race", "-tags=integration", "./..."]
     depends_on:
       - neo4j
+      - opa
   neo4j:
     image: neo4j:4.4-enterprise
     environment:
@@ -22,3 +24,12 @@ services:
     ports:
       - "7474:7474"
       - "7687:7687"
+  opa:
+    image: openpolicyagent/opa:0.57.0
+    ports:
+      - "8181:8181"
+    command:
+      - "run"
+      - "--server"
+      - "--log-format=json-pretty"
+      - "--set=decision_logs.console=true"

--- a/helm/content-rw-neo4j/templates/deployment.yaml
+++ b/helm/content-rw-neo4j/templates/deployment.yaml
@@ -18,6 +18,7 @@ spec:
         app: {{ .Values.service.name }}
         visualize: "true"
     spec:
+      serviceAccountName: {{ .Values.serviceAccount }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -58,4 +59,48 @@ spec:
           timeoutSeconds: 4
         resources:
 {{ toYaml .Values.resources | indent 12 }}
-
+      {{- if .Values.openPolicyAgentSidecar }}
+      - name: "{{ .Values.openPolicyAgentSidecar.name }}"
+        image: "{{ .Values.openPolicyAgentSidecar.repository }}:{{ .Values.openPolicyAgentSidecar.tag }}"
+        imagePullPolicy: {{ .Values.openPolicyAgentSidecar.pullPolicy }}
+        env:
+          - name: POLICY_BUCKET
+            valueFrom:
+              configMapKeyRef:
+                name: global-config
+                key: opa.policy.bucket
+          - name: AWS_REGION
+            valueFrom:
+              configMapKeyRef:
+                name: global-config
+                key: aws.region
+        ports:
+          - name: http
+            containerPort: 8181
+        livenessProbe:
+          httpGet:
+            path: /health
+            scheme: HTTP
+            port: 8181
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /health?bundle=true
+            scheme: HTTP
+            port: 8181
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        args:
+          - "run"
+          - "--ignore=.*"
+          - "--server"
+          - "--set=decision_logs.console=true"
+          - "--log-format=json-pretty"
+          - "--set=services.bundlesS3Bucket.url=$(POLICY_BUCKET)"
+          - "--set=services.bundlesS3Bucket.credentials.s3_signing.web_identity_credentials.aws_region=$(AWS_REGION)"
+          - "--set=bundles.contentRWNeo4j.service=bundlesS3Bucket"
+          - "--set=bundles.contentRWNeo4j.resource=content_rw_neo4j.bundle.tar.gz"
+          - "--set=bundles.contentRWNeo4j.polling.min_delay_seconds=120"
+          - "--set=bundles.contentRWNeo4j.polling.max_delay_seconds=300"
+      {{- end}}

--- a/helm/content-rw-neo4j/templates/service.yaml
+++ b/helm/content-rw-neo4j/templates/service.yaml
@@ -13,7 +13,6 @@ metadata:
 spec:
   ports: 
     - port: 8080 
-#      name: # The name of this port within the service. Optional if only one port is defined on this service
-      targetPort: 8080 
+      targetPort: 8080
   selector: 
     app: {{ .Values.service.name }} 

--- a/helm/content-rw-neo4j/values.yaml
+++ b/helm/content-rw-neo4j/values.yaml
@@ -8,6 +8,12 @@ replicaCount: 2
 image:
   repository: coco/content-rw-neo4j
   pullPolicy: IfNotPresent
+openPolicyAgentSidecar:
+  name: open-policy-agent
+  repository: openpolicyagent/opa
+  tag: 0.57.0
+  pullPolicy: IfNotPresent
+serviceAccount: eksctl-upp-content-rw-neo4j-serviceaccount
 resources:
   requests:
     memory: 40Mi

--- a/helm/content-rw-neo4j/values.yaml
+++ b/helm/content-rw-neo4j/values.yaml
@@ -13,7 +13,7 @@ openPolicyAgentSidecar:
   repository: openpolicyagent/opa
   tag: 0.57.0
   pullPolicy: IfNotPresent
-serviceAccount: eksctl-upp-content-rw-neo4j-serviceaccount
+serviceAccount: eksctl-content-rw-neo4j-serviceaccount
 resources:
   requests:
     memory: 40Mi

--- a/policy/agent.go
+++ b/policy/agent.go
@@ -1,0 +1,107 @@
+package policy
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/Financial-Times/go-logger/v2"
+)
+
+const SpecialContentKey string = "SPECIAL_CONTENT"
+const pathPrefix string = "v1/data"
+
+type Agent struct {
+	url        string
+	paths      map[string]string
+	httpClient *http.Client
+	logger     *logger.UPPLogger
+}
+
+func NewAgent(u string, p map[string]string, c *http.Client, l *logger.UPPLogger) *Agent {
+	return &Agent{
+		url:        u,
+		paths:      p,
+		httpClient: c,
+		logger:     l,
+	}
+}
+
+func (a *Agent) CheckSpecialContentPolicy(q SpecialContentQuery) (*Decision, error) {
+	specialContentPath, ok := a.paths[SpecialContentKey]
+	if !ok {
+		return nil, &QueryMissingPathConfigError{Key: SpecialContentKey}
+	}
+
+	res, err := a.queryPolicyAgent(q, specialContentPath)
+	if err != nil {
+		return nil, err
+	}
+
+	m := make(map[string]interface{})
+	err = json.Unmarshal(res, &m)
+	if err != nil {
+		return nil, &DecisionUnmarshallError{Err: err}
+	}
+
+	d := Decision{}
+
+	decisionID, ok := m["decision_id"].(string)
+	if !ok {
+		return nil, &DecisionPayloadError{Msg: "could not cast decision_id to string"}
+	}
+	d.DecisionID = decisionID
+
+	result, ok := m["result"].(map[string]interface{})
+	if !ok {
+		return nil, &DecisionPayloadError{Msg: "result is either nil or there was a problem casting it"}
+	}
+
+	isSpecialContent, ok := result["is_special_content"].(bool)
+	if !ok {
+		return nil, &DecisionPayloadError{Msg: "could not cast is_special_content to bool"}
+	}
+
+	sd := SpecialContentDecision{}
+	sd.IsSpecialContent = isSpecialContent
+
+	d.Result = sd
+
+	return &d, nil
+}
+
+func (a *Agent) queryPolicyAgent(query interface{}, path string) ([]byte, error) {
+	q := Query{
+		Input: query,
+	}
+
+	m, err := json.Marshal(q)
+	if err != nil {
+		return nil, &QueryMarshallError{Err: err}
+	}
+
+	req, err := http.NewRequest(
+		"POST",
+		fmt.Sprintf("%s/%s/%s", a.url, pathPrefix, path),
+		bytes.NewReader(m),
+	)
+	if err != nil {
+		return nil, &QueryRequestCreationError{Err: err}
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := a.httpClient.Do(req)
+	if err != nil {
+		return nil, &QueryRequestError{Err: err}
+	}
+	defer res.Body.Close()
+
+	b, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, &QueryResponseReadingError{Err: err}
+	}
+
+	return b, nil
+}

--- a/policy/agent_test.go
+++ b/policy/agent_test.go
@@ -1,0 +1,151 @@
+package policy
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/Financial-Times/go-logger/v2"
+)
+
+const specialContentEditorialDesk string = "/FT/Professional/Central Banking"
+
+func TestAgent_CheckSpecialContentPolicyNoPathsConfig(t *testing.T) {
+	q := SpecialContentQuery{
+		EditorialDesk: specialContentEditorialDesk,
+	}
+
+	a := NewAgent("", make(map[string]string), nil, nil)
+
+	_, err := a.CheckSpecialContentPolicy(q)
+	assert.NotNil(t, err)
+	assert.IsType(t, &QueryMissingPathConfigError{}, err)
+}
+
+func TestAgent_CheckSpecialContentPolicyEmptyResult(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write(
+			[]byte(`{"decision_id": "TEST_UUID"}`),
+		)
+		if err != nil {
+			t.Logf(
+				"could not setup test server, failed to send mock response: %s",
+				err,
+			)
+			t.FailNow()
+		}
+	}))
+	defer srv.Close()
+
+	q := SpecialContentQuery{
+		EditorialDesk: specialContentEditorialDesk,
+	}
+	p := map[string]string{
+		SpecialContentKey: "content_rw_neo4j/special_content",
+	}
+	c := http.Client{}
+	l := logger.UPPLogger{}
+
+	a := NewAgent(srv.URL, p, &c, &l)
+
+	_, err := a.CheckSpecialContentPolicy(q)
+
+	assert.NotNil(t, err)
+	assert.IsType(t, &DecisionPayloadError{}, err)
+}
+
+func TestAgent_CheckSpecialContentPolicy(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Logf(
+				"could not setup test server, failed to read mock request: %s",
+				err,
+			)
+			t.FailNow()
+		}
+
+		m := make(map[string]interface{})
+		err = json.Unmarshal(b, &m)
+		if err != nil {
+			t.Logf(
+				"could not setup test server, failed to unmarshal mock request: %s",
+				err,
+			)
+			t.FailNow()
+		}
+
+		if m["input"].(map[string]interface{})["editorialDesk"] == specialContentEditorialDesk {
+			_, err := w.Write(
+				[]byte(`{"decision_id": "TEST_UUID", "result": {"is_special_content": true}}`),
+			)
+			if err != nil {
+				t.Logf(
+					"could not setup test server, failed to send mock response: %s",
+					err,
+				)
+				t.FailNow()
+			}
+		} else {
+			_, err := w.Write([]byte(`{"decision_id": "TEST_UUID", "result": {"is_special_content": false}}`))
+			if err != nil {
+				t.Logf(
+					"could not setup test server, failed to send mock response: %s",
+					err,
+				)
+				t.FailNow()
+			}
+		}
+	}))
+	defer srv.Close()
+
+	tests := []struct {
+		name     string
+		query    SpecialContentQuery
+		expected bool
+	}{
+		{
+			name: "Special content editorial desk.",
+			query: SpecialContentQuery{
+				EditorialDesk: specialContentEditorialDesk,
+			},
+			expected: true,
+		},
+		{
+			name: "Standard content editorial desk.",
+			query: SpecialContentQuery{
+				EditorialDesk: "/FT/Professional/Standard Content",
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			p := map[string]string{
+				SpecialContentKey: "content_rw_neo4j/special_content",
+			}
+			c := http.Client{}
+			l := logger.UPPLogger{}
+
+			a := NewAgent(srv.URL, p, &c, &l)
+
+			d, err := a.CheckSpecialContentPolicy(test.query)
+			if err != nil {
+				t.Logf(
+					"an error occurred while testing CheckSpecialContentPolicy: %s",
+					err,
+				)
+				t.FailNow()
+			}
+
+			assert.Equal(t, test.expected, d.Result.(SpecialContentDecision).IsSpecialContent)
+		})
+	}
+}

--- a/policy/decision.go
+++ b/policy/decision.go
@@ -1,0 +1,10 @@
+package policy
+
+type Decision struct {
+	DecisionID string      `json:"decision_id,omitempty"`
+	Result     interface{} `json:"result"`
+}
+
+type SpecialContentDecision struct {
+	IsSpecialContent bool `json:"is_special_content"`
+}

--- a/policy/error.go
+++ b/policy/error.go
@@ -1,0 +1,77 @@
+package policy
+
+import "fmt"
+
+type QueryMissingPathConfigError struct {
+	Key string
+}
+
+func (e *QueryMissingPathConfigError) Error() string {
+	return fmt.Sprintf("key %s missing from path config supplied to the policy agent client.", e.Key)
+}
+
+type QueryMarshallError struct {
+	Err error
+}
+
+func (e *QueryMarshallError) Error() string {
+	return fmt.Sprintf(
+		"an error occurred while attempting to marshall a query for the policy engine: %s.",
+		e.Err,
+	)
+}
+
+type DecisionUnmarshallError struct {
+	Err error
+}
+
+func (e *DecisionUnmarshallError) Error() string {
+	return fmt.Sprintf(
+		"an error occurred while attempting to unmarshall a decision from the policy engine: %s.",
+		e.Err,
+	)
+}
+
+type DecisionPayloadError struct {
+	Msg string
+}
+
+func (e *DecisionPayloadError) Error() string {
+	return fmt.Sprintf(
+		"there was a problem with the decision payload: %s.",
+		e.Msg,
+	)
+}
+
+type QueryRequestCreationError struct {
+	Err error
+}
+
+func (e *QueryRequestCreationError) Error() string {
+	return fmt.Sprintf(
+		"an error occurred while constructing a query request for the policy engine: %s.",
+		e.Err,
+	)
+}
+
+type QueryRequestError struct {
+	Err error
+}
+
+func (e *QueryRequestError) Error() string {
+	return fmt.Sprintf(
+		"an error occurred while performing a query request to the policy engine: %s.",
+		e.Err,
+	)
+}
+
+type QueryResponseReadingError struct {
+	Err error
+}
+
+func (e *QueryResponseReadingError) Error() string {
+	return fmt.Sprintf(
+		"an error occurred while reading a response from the policy engine: %s.",
+		e.Err,
+	)
+}

--- a/policy/query.go
+++ b/policy/query.go
@@ -1,0 +1,9 @@
+package policy
+
+type Query struct {
+	Input interface{} `json:"input"`
+}
+
+type SpecialContentQuery struct {
+	EditorialDesk string `json:"editorialDesk"`
+}


### PR DESCRIPTION
# Description

## What

This PR intends to integrate Open Policy Engine (OPA) in content-rw-neo4j. The code is structured in such a way that it facilitates the usage of OPA running in a sidecar container. To this effect what was done as part of this PR is the following:

- Created a self-contained policy package, it is used to facilitate communication to the policy engine.
- Extended the content model to include editorialDesk.
- Wrote logic that uses the aforementioned policy package.
- Added sidecar config for k8s.
- Added an additional service, which configures OPA in the docker-compost-tests.yml file.

## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-4642)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)