### PR TITLE
Make bundle name consistent with the naming convention from the policy repo

### DIFF
--- a/helm/content-rw-neo4j/templates/deployment.yaml
+++ b/helm/content-rw-neo4j/templates/deployment.yaml
@@ -96,7 +96,7 @@ spec:
           # The region below is hardcoded because the default location for the bucket (the one appended to the url above) is set to eu-west-1, it's not a mistake.
           - "--set=services.bundlesS3Bucket.credentials.s3_signing.web_identity_credentials.aws_region=eu-west-1"
           - "--set=bundles.contentRWNeo4j.service=bundlesS3Bucket"
-          - "--set=bundles.contentRWNeo4j.resource=content_rw_neo4j.bundle.tar.gz"
+          - "--set=bundles.contentRWNeo4j.resource=content-rw-neo4j.bundle.tar.gz"
           - "--set=bundles.contentRWNeo4j.polling.min_delay_seconds=120"
           - "--set=bundles.contentRWNeo4j.polling.max_delay_seconds=300"
       {{- end}}


### PR DESCRIPTION
# Description

## What

This PR intends to tweak the helm configuration and particularly the name with which the OPA policy bundle is referenced.
It changes the name of the service to use dashes (-) rather than underscores (_), this is necessary because of the naming convention required by cm-opa-compiler. The CircleCI pipeline in the said repo deploys the bundles with dashes in the names.

## Why

[https://financialtimes.atlassian.net/browse/UPPSF-4761](JIRA)

## Scope and particulars of this PR (Please tick all that apply)

- [x] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)
___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
